### PR TITLE
fix(devtool): break long words in log detail for preventing horizontal scroll

### DIFF
--- a/.changeset/puny-horses-grab.md
+++ b/.changeset/puny-horses-grab.md
@@ -1,0 +1,6 @@
+---
+"@tapsioss/client-socket-manager": patch
+---
+
+Break long words in DevTool's log details for preventing horizontal scroll.
+  

--- a/packages/core/src/devtool/devtool.ts
+++ b/packages/core/src/devtool/devtool.ts
@@ -143,6 +143,7 @@ export const renderLog = (log: Log) => {
     "font-size": "0.625rem",
     "margin-top": "0",
     color: LogTypeColor[log.type],
+    "overflow-wrap": "break-word",
   });
 
   const timeStyle = generateInlineStyle({


### PR DESCRIPTION
Closing #23 